### PR TITLE
fix make crd-component-apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-ARTIFACT_ID=k8s-debug-mode-cr-lib
+PROJECT_NAME=k8s-debug-mode-cr-lib
+ARTIFACT_ID=k8s-debug-mode-operator-crd
+APPEND_CRD_SUFFIX=false
 VERSION=0.2.3
 GOTAG=1.24.1
 MAKEFILES_VERSION=10.2.0

--- a/k8s/helm-crd/templates/debugmode-crd.yaml
+++ b/k8s/helm-crd/templates/debugmode-crd.yaml
@@ -6,7 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     app: ces
-    app.kubernetes.io/name: k8s-debug-mode-cr-lib-crd
+    app.kubernetes.io/name: k8s-debug-mode-operator-crd
     k8s.cloudogu.com/component.name: k8s-debug-mode-operator-crd
 spec:
   group: k8s.cloudogu.com


### PR DESCRIPTION
without these change crd-component-apply will fail because the make target will not find the gz file